### PR TITLE
fix(*): Don't bring background windows to front

### DIFF
--- a/Penc.xcodeproj/project.pbxproj
+++ b/Penc.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		002029BBAAD3F763E4802CFB /* Pods_Penc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86BC15AF2221EE6872E73AA3 /* Pods_Penc.framework */; };
+		80E0F4932230A6FD0084F0AC /* SIWindowExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E0F4922230A6FD0084F0AC /* SIWindowExtension.swift */; };
 		9417B7C11FADB16300749BC8 /* GestureOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9417B7C01FADB16300749BC8 /* GestureOverlayWindow.swift */; };
 		9417B7CB1FB04A0100749BC8 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9417B7CA1FB04A0100749BC8 /* Preferences.swift */; };
 		945195A41FA88B8B00FA53B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945195A31FA88B8B00FA53B4 /* AppDelegate.swift */; };
@@ -46,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		286EA375C63E4401015BCE4C /* Pods-Penc.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Penc.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Penc/Pods-Penc.debug.xcconfig"; sourceTree = "<group>"; };
+		80E0F4922230A6FD0084F0AC /* SIWindowExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SIWindowExtension.swift; sourceTree = "<group>"; };
 		86BC15AF2221EE6872E73AA3 /* Pods_Penc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Penc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9417B7C01FADB16300749BC8 /* GestureOverlayWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureOverlayWindow.swift; sourceTree = "<group>"; };
 		9417B7CA1FB04A0100749BC8 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				945195AC1FA88B8B00FA53B4 /* Info.plist */,
 				945195AD1FA88B8B00FA53B4 /* Penc.entitlements */,
 				94763F721FA8DE5800D60C27 /* CGRectExtension.swift */,
+				80E0F4922230A6FD0084F0AC /* SIWindowExtension.swift */,
 				94763F7E1FA9095E00D60C27 /* PreferencesViewController.swift */,
 				9417B7C01FADB16300749BC8 /* GestureOverlayWindow.swift */,
 				9417B7CA1FB04A0100749BC8 /* Preferences.swift */,
@@ -370,6 +373,7 @@
 				9417B7CB1FB04A0100749BC8 /* Preferences.swift in Sources */,
 				94C5FCCD1FB222CA00916D97 /* PTimer.swift in Sources */,
 				94C5FCCB1FB2201200916D97 /* ActivationHandler.swift in Sources */,
+				80E0F4932230A6FD0084F0AC /* SIWindowExtension.swift in Sources */,
 				945195A41FA88B8B00FA53B4 /* AppDelegate.swift in Sources */,
 				9417B7C11FADB16300749BC8 /* GestureOverlayWindow.swift in Sources */,
 				94C5FCD11FB347DA00916D97 /* PlaceholderWindowViewController.swift in Sources */,

--- a/Penc/AppDelegate.swift
+++ b/Penc/AppDelegate.swift
@@ -318,7 +318,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, GestureOverlayWindowDelegate
         
         let newRect = self.placeholderWindow.frame.topLeft2bottomLeft(NSScreen.screens[0])
         self.selectedWindow!.setFrame(newRect)
-        self.focusedWindow?.focus()
+        self.focusedWindow?.focusThisWindowOnly()
         self.placeholderWindow.orderOut(self.placeholderWindow)
         self.gestureOverlayWindow.orderOut(self.gestureOverlayWindow)
         self.gestureOverlayWindow.clear()

--- a/Penc/SIWindowExtension.swift
+++ b/Penc/SIWindowExtension.swift
@@ -1,0 +1,16 @@
+//
+//  SIWindowExtension.swift
+//  Penc
+//
+//  Created by Lukas Stabe on 07.03.2019
+//  Copyright © 2019 Deniz Gurkaynak. All rights reserved.
+//
+
+import Silica
+
+extension SIWindow {
+    func focusThisWindowOnly() {
+        NSRunningApplication(processIdentifier: processIdentifier())?.activate(options: .activateIgnoringOtherApps)
+        AXUIElementSetAttributeValue(axElementRef, NSAccessibilityAttributeName.main.rawValue as CFString, kCFBooleanTrue)
+    }
+}


### PR DESCRIPTION
The default SIWindow focus method moves other windows of the application the instance belongs to in front of other apps.

To reproduce, open two Safari windows, plus a third from another app, with one Safari window behind, and one in front of the other app. Then move the front Safari window using Penc. The background window will jump in front of the other app.

This pr fixes that, although one could argue `focusThisWindowOnly` should belong in Silica rather than Penc 🤷‍♀️ 